### PR TITLE
Implement basic FastAPI backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # stocky
-stocky is a stock management system
+Stocky is a stock management system.
+
+## Backend
+
+This repository now includes a simple [FastAPI](https://fastapi.tiangolo.com/) backend under `backend/`.
+
+### Run the API
+
+```bash
+cd backend
+pip install -r requirements.txt
+uvicorn main:app --reload --port 8000
+```
+
+The frontend looks for the backend at the URL defined by `NEXT_PUBLIC_API_URL` (defaults to `http://localhost:8000`).

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,27 @@
+# Stocky Backend
+
+This directory contains a simple FastAPI backend used during development.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+
+```bash
+uvicorn main:app --reload --port 8000
+```
+
+The API will be available at `http://localhost:8000`.
+
+## Endpoints
+
+- `POST /auth/login` – authenticate a user (password is `password` for demo)
+- `GET /stock/` – list stock items
+- `POST /stock/assign` – assign an item to a user
+- `POST /stock/return` – return an item to inventory
+- `GET /users` – list users
+- `GET /departments` – list departments
+- `GET /logs/` – list audit logs

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,127 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from typing import List, Optional
+from datetime import datetime
+
+app = FastAPI()
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+class LoginResponse(BaseModel):
+    token: str
+    user: User
+
+class StockItem(BaseModel):
+    id: int
+    name: str
+    quantity: int
+    department_id: int
+    status: str
+
+class AssignRequest(BaseModel):
+    stock_item_id: int
+    assignee_user_id: int
+    reason: Optional[str] = None
+
+class ReturnRequest(BaseModel):
+    item_id: int
+    reason: str
+    condition: Optional[str] = None
+
+class User(BaseModel):
+    id: int
+    username: str
+    email: str
+    department_id: int
+    full_name: str
+
+class Department(BaseModel):
+    id: int
+    name: str
+
+class LogEntry(BaseModel):
+    id: int
+    timestamp: datetime
+    action: str
+    details: dict
+
+# In-memory demo data
+users = [
+    User(id=1, username="admin", email="admin@example.com", department_id=1, full_name="Admin User"),
+    User(id=2, username="manager", email="manager@example.com", department_id=2, full_name="Stock Manager"),
+]
+
+departments = [
+    Department(id=1, name="Warehouse"),
+    Department(id=2, name="IT Department"),
+]
+
+stock_items = [
+    StockItem(id=1, name="Dell Laptop XPS 13", quantity=5, department_id=1, status="available"),
+    StockItem(id=2, name="iPhone 15 Pro", quantity=12, department_id=1, status="available"),
+    StockItem(id=3, name="Wireless Mouse", quantity=2, department_id=1, status="available"),
+]
+
+logs: List[LogEntry] = []
+
+@app.post("/auth/login", response_model=LoginResponse)
+def login(data: LoginRequest):
+    user = next((u for u in users if u.username == data.username), None)
+    if not user or data.password != "password":
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    token = f"token-{user.id}-{int(datetime.utcnow().timestamp())}"
+    return {"token": token, "user": user}
+
+@app.get("/stock/", response_model=List[StockItem])
+def get_stock():
+    return stock_items
+
+@app.post("/stock/assign")
+def assign_item(data: AssignRequest):
+    item = next((s for s in stock_items if s.id == data.stock_item_id), None)
+    if not item:
+        raise HTTPException(status_code=404, detail="Item not found")
+    if item.quantity <= 0:
+        raise HTTPException(status_code=400, detail="Item out of stock")
+    item.quantity -= 1
+    item.status = "assigned"
+    logs.append(
+        LogEntry(
+            id=len(logs)+1,
+            timestamp=datetime.utcnow(),
+            action="assign",
+            details=data.dict(),
+        )
+    )
+    return {"success": True, "message": "Item assigned"}
+
+@app.post("/stock/return")
+def return_item(data: ReturnRequest):
+    item = next((s for s in stock_items if s.id == data.item_id), None)
+    if not item:
+        raise HTTPException(status_code=404, detail="Item not found")
+    item.quantity += 1
+    item.status = "available"
+    logs.append(
+        LogEntry(
+            id=len(logs)+1,
+            timestamp=datetime.utcnow(),
+            action="return",
+            details=data.dict(),
+        )
+    )
+    return {"success": True, "message": "Item returned"}
+
+@app.get("/users", response_model=List[User])
+def get_users():
+    return users
+
+@app.get("/departments", response_model=List[Department])
+def get_departments():
+    return departments
+
+@app.get("/logs/", response_model=List[LogEntry])
+def get_logs():
+    return logs

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/frontend/hooks/useAuth.ts
+++ b/frontend/hooks/useAuth.ts
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
+import { stockApi } from "@/lib/api"
 import type { User } from "@/types/stock"
 
 interface LoginCredentials {
@@ -51,66 +52,16 @@ export function useAuth() {
     setLoading(true)
 
     try {
-      // Simulate API call
-      await new Promise((resolve) => setTimeout(resolve, 1000))
+      const response = await stockApi.login(credentials)
+      localStorage.setItem("access_token", response.token)
+      localStorage.setItem("user_data", JSON.stringify(response.user))
+      setUser(response.user)
 
-      // Mock authentication logic
-      const mockUsers: User[] = [
-        {
-          id: 1,
-          username: "admin",
-          email: "admin@company.com",
-          roles: ["admin"],
-          department_id: 1,
-          full_name: "System Administrator",
-        },
-        {
-          id: 2,
-          username: "manager",
-          email: "manager@company.com",
-          roles: ["stock_manager"],
-          department_id: 2,
-          full_name: "Stock Manager",
-        },
-        {
-          id: 3,
-          username: "staff",
-          email: "staff@company.com",
-          roles: ["staff"],
-          department_id: 2,
-          full_name: "Staff Member",
-        },
-        {
-          id: 4,
-          username: "john_manager",
-          email: "john.manager@company.com",
-          roles: ["stock_manager", "staff"],
-          department_id: 2,
-          full_name: "John Manager",
-        },
-      ]
-
-      const foundUser = mockUsers.find(
-        (u) => u.username === credentials.username && credentials.password === "password", // Simple mock password
-      )
-
-      if (foundUser) {
-        const token = `mock_token_${foundUser.id}_${Date.now()}`
-        localStorage.setItem("access_token", token)
-        localStorage.setItem("user_data", JSON.stringify(foundUser))
-        setUser(foundUser)
-
-        return {
-          success: true,
-          message: "Login successful",
-          user: foundUser,
-          token,
-        }
-      } else {
-        return {
-          success: false,
-          message: "Invalid username or password",
-        }
+      return {
+        success: true,
+        message: "Login successful",
+        user: response.user,
+        token: response.token,
       }
     } catch (error) {
       return {


### PR DESCRIPTION
## Summary
- implement a FastAPI backend with simple in-memory data
- connect the frontend API helpers to the backend endpoints
- hook the authentication hook up to new login endpoint
- document how to run the new backend

## Testing
- `npm install`
- `npm run lint` *(fails: various lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685145c273c88331b383c311d35dd083