### PR TITLE
Add initial seed script and role support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Install requirements and run migrations:
 cd backend
 pip install -r requirements.txt
 alembic upgrade head
+python ../scripts/seed_initial_data.py  # populate demo data
 uvicorn backend.main:app --reload --port 8000
 ```
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -15,15 +15,24 @@ def seed_data():
         if not db.query(models.User).first():
             dept1 = models.Department(id=1, name="Warehouse")
             dept2 = models.Department(id=2, name="IT Department")
-            db.add_all([dept1, dept2])
+            dept3 = models.Department(id=3, name="Finance")
+            db.add_all([dept1, dept2, dept3])
             db.add_all([
-                models.User(id=1, username="admin", email="admin@example.com", department_id=1, full_name="Admin User"),
-                models.User(id=2, username="manager", email="manager@example.com", department_id=2, full_name="Stock Manager"),
+                models.User(id=1, username="admin", email="admin@example.com", department_id=1, full_name="Admin User", role="admin"),
+                models.User(id=2, username="manager", email="manager@example.com", department_id=2, full_name="Stock Manager", role="stock_manager"),
+                models.User(id=3, username="alice", email="alice@example.com", department_id=3, full_name="Alice Accountant", role="staff"),
+                models.User(id=4, username="viewer", email="viewer@example.com", department_id=1, full_name="View Only", role="viewer"),
             ])
             db.add_all([
                 models.StockItem(id=1, name="Dell Laptop XPS 13", quantity=5, department_id=1, status="available"),
                 models.StockItem(id=2, name="iPhone 15 Pro", quantity=12, department_id=1, status="available"),
                 models.StockItem(id=3, name="Wireless Mouse", quantity=2, department_id=1, status="available"),
+                models.StockItem(id=4, name="Office Chair", quantity=10, department_id=2, status="available"),
+                models.StockItem(id=5, name="Projector", quantity=1, department_id=3, status="available"),
+            ])
+            db.add_all([
+                models.LogEntry(action="assign", details="{'item':1,'user':2}"),
+                models.LogEntry(action="return", details="{'item':1,'user':2}"),
             ])
             db.commit()
     finally:

--- a/backend/migrations/versions/1b2f3c4d5e6f_add_role_column.py
+++ b/backend/migrations/versions/1b2f3c4d5e6f_add_role_column.py
@@ -1,0 +1,23 @@
+"""add role column
+
+Revision ID: 1b2f3c4d5e6f
+Revises: 70923ce915b5
+Create Date: 2025-06-17 12:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '1b2f3c4d5e6f'
+down_revision = '70923ce915b5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('role', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'role')

--- a/backend/models.py
+++ b/backend/models.py
@@ -18,6 +18,7 @@ class User(Base):
     email = Column(String, nullable=False)
     department_id = Column(Integer, ForeignKey("departments.id"))
     full_name = Column(String)
+    role = Column(String, default="staff")
     department = relationship("Department", back_populates="users")
 
 class StockItem(Base):

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -7,6 +7,7 @@ class UserBase(BaseModel):
     email: str
     department_id: int
     full_name: Optional[str] = None
+    role: str = "staff"
 
 class UserCreate(UserBase):
     pass

--- a/scripts/seed_initial_data.py
+++ b/scripts/seed_initial_data.py
@@ -1,0 +1,59 @@
+"""Seed the database with initial demo data."""
+from backend.database import SessionLocal, engine
+from backend import models
+
+models.Base.metadata.create_all(bind=engine)
+
+
+def seed():
+    db = SessionLocal()
+    try:
+        # Departments
+        if db.query(models.Department).count() == 0:
+            departments = [
+                models.Department(name="Warehouse"),
+                models.Department(name="IT Department"),
+                models.Department(name="Finance"),
+                models.Department(name="Operations"),
+            ]
+            db.add_all(departments)
+            db.flush()  # assign IDs
+
+        # Users with different permission levels
+        if db.query(models.User).count() == 0:
+            users = [
+                models.User(username="admin", email="admin@example.com", department_id=1, full_name="Admin User", role="admin"),
+                models.User(username="manager", email="manager@example.com", department_id=1, full_name="Stock Manager", role="stock_manager"),
+                models.User(username="staff", email="staff@example.com", department_id=2, full_name="Regular Staff", role="staff"),
+                models.User(username="viewer", email="viewer@example.com", department_id=3, full_name="View Only", role="viewer"),
+            ]
+            db.add_all(users)
+
+        # Stock items
+        if db.query(models.StockItem).count() == 0:
+            items = [
+                models.StockItem(name="Dell Laptop XPS 13", quantity=5, department_id=1, status="available"),
+                models.StockItem(name="iPhone 15 Pro", quantity=12, department_id=1, status="available"),
+                models.StockItem(name="Wireless Mouse", quantity=20, department_id=2, status="available"),
+                models.StockItem(name="Office Chair", quantity=10, department_id=2, status="available"),
+                models.StockItem(name="Projector", quantity=2, department_id=3, status="available"),
+            ]
+            db.add_all(items)
+
+        # Logs for audit testing
+        if db.query(models.LogEntry).count() == 0:
+            logs = [
+                models.LogEntry(action="assign", details="{'item': 1, 'user': 2}"),
+                models.LogEntry(action="return", details="{'item': 1, 'user': 2}"),
+                models.LogEntry(action="assign", details="{'item': 2, 'user': 3}"),
+            ]
+            db.add_all(logs)
+
+        db.commit()
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    seed()
+    print("Database seeded with initial data.")


### PR DESCRIPTION
## Summary
- add `role` column to `User` model and schema
- extend backend seeding to create extra departments, users, stock items and logs
- include Alembic migration for the new column
- provide standalone `scripts/seed_initial_data.py` for populating demo data
- document seeding in README

## Testing
- `python -m py_compile backend/main.py backend/models.py backend/schemas.py scripts/seed_initial_data.py backend/migrations/versions/1b2f3c4d5e6f_add_role_column.py`

------
https://chatgpt.com/codex/tasks/task_e_68516100f39c8331a754f3c298cc05c6